### PR TITLE
Extract common configuration into shared common.dtsi

### DIFF
--- a/config/charybdis.keymap
+++ b/config/charybdis.keymap
@@ -6,17 +6,7 @@
 #include <dt-bindings/zmk/pointing.h>
 #include "combos.dtsi"
 #include "behaviours.dtsi"
-
-&caps_word { continue-list = <NB_UNDERSCORE NB_MINUS WNB_UNDERSCORE WNB_MINUS BACKSPACE DEL>; };
-
-// Change sticky key defaults
-
-&sk {
-    release-after-ms = <2000>;
-    quick-release;
-};
-
-&lt { quick-tap-ms = <175>; };
+#include "common.dtsi"
 
 / {
     chosen { zmk,matrix_transform = &five_column_transform; };

--- a/config/common.dtsi
+++ b/config/common.dtsi
@@ -1,0 +1,12 @@
+// Common configuration settings shared across all keyboards
+
+// Caps word configuration - allows underscore, minus, backspace, and delete
+&caps_word { continue-list = <NB_UNDERSCORE NB_MINUS WNB_UNDERSCORE WNB_MINUS BACKSPACE DEL>; };
+
+// Sticky key defaults
+&sk {
+    quick-release;
+};
+
+// Layer tap configuration
+&lt { quick-tap-ms = <175>; };

--- a/config/forager.keymap
+++ b/config/forager.keymap
@@ -6,17 +6,7 @@
 #include <dt-bindings/zmk/pointing.h>
 #include "combos.dtsi"
 #include "behaviours.dtsi"
-
-&caps_word { continue-list = <NB_UNDERSCORE NB_MINUS WNB_UNDERSCORE WNB_MINUS BACKSPACE DEL>; };
-
-// Change sticky key defaults
-
-&sk {
-    quick-release;
-    lazy;
-};
-
-&lt { quick-tap-ms = <175>; };
+#include "common.dtsi"
 
 / {
     keymap {

--- a/config/visorbearer.keymap
+++ b/config/visorbearer.keymap
@@ -8,16 +8,7 @@
 #include "combos32.dtsi"
 #include <behaviors/visorbearer_led.dtsi>
 #include "behaviours.dtsi"
-
-&caps_word { continue-list = <NB_UNDERSCORE NB_MINUS WNB_UNDERSCORE WNB_MINUS BACKSPACE DEL>; };
-
-// Change sticky key defaults
-
-&sk {
-    quick-release;
-};
-
-&lt { quick-tap-ms = <175>; };
+#include "common.dtsi"
 
 / {
     // Override behaviors for 32-key layout


### PR DESCRIPTION
Created config/common.dtsi with shared settings:
- caps_word configuration (continue list)
- sticky key defaults (quick-release)
- layer tap quick-tap timing

Updated all keymaps to use common.dtsi:
- charybdis: removed release-after-ms, now uses standard quick-release
- forager: removed lazy parameter, now uses standard quick-release
- visorbearer: already used this config, just moved to common file

All keyboards now use consistent configuration settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)